### PR TITLE
Nesting algorithms 

### DIFF
--- a/workflow/rules/filename_patterns.py
+++ b/workflow/rules/filename_patterns.py
@@ -70,5 +70,13 @@ def time_path(algorithm):
 def data_path():
     return "{output_dir}/data/adjmat=/{adjmat}/parameters=/{bn}/data=/{data}/seed={replicate}.csv"
 
+
 def adjmat_true_path():
     return "{output_dir}/adjmat/{adjmat}.csv",
+
+
+def path_to_input_algorithm_graph(alg_id):
+    return "{output_dir}/adjmat_estimate/{data}/"\
+        "algorithm=/" + json_string[alg_id][0] + "/" +\
+        "seed={replicate}/" \
+        "adjmat.csv"

--- a/workflow/rules/module_strings.py
+++ b/workflow/rules/module_strings.py
@@ -53,14 +53,6 @@ def is_single_output_run(run_config: dict) -> bool:
  
 json_string = {}
 
-for alg in config["resources"]["structure_learning_algorithms"].keys():
-    alg_config = config["resources"]["structure_learning_algorithms"][alg]
-    for run in alg_config:
-        for key, item in run.items():
-            if key == 'input_algorithm_id':
-                print(f"alg {alg}, item {item}, path {idtopath(item)}")
-
-
 # Generate strings from the config file.
 for alg in config["resources"]["structure_learning_algorithms"]:
     # Some algorihtm takes input graphs. These are treated separately.

--- a/workflow/rules/structure_learning_algorithms/equsa_psilearner/rule.smk
+++ b/workflow/rules/structure_learning_algorithms/equsa_psilearner/rule.smk
@@ -4,7 +4,7 @@ rule:
         module_name
     input:
         data=alg_input_data(),
-        input_algorithm=lambda wildcards: path_to_input_algorithm_graph(wildcards.input_algorithm_id) if hasattr(wildcards, 'input_algorithm_id') else "None",
+        input_algorithm=lambda wildcards: path_to_input_algorithm_graph(wildcards.input_algorithm_id) if hasattr(wildcards, 'input_algorithm_id') else [],
     output:
         adjmat=alg_output_adjmat_path(module_name),
         time=touch(alg_output_time_path(module_name)),

--- a/workflow/rules/structure_learning_algorithms/equsa_psilearner/rule.smk
+++ b/workflow/rules/structure_learning_algorithms/equsa_psilearner/rule.smk
@@ -4,6 +4,7 @@ rule:
         module_name
     input:
         data=alg_input_data(),
+        input_algorithm=lambda wildcards: path_to_input_algorithm_graph(wildcards.input_algorithm_id) if hasattr(wildcards, 'input_algorithm_id') else "None",
     output:
         adjmat=alg_output_adjmat_path(module_name),
         time=touch(alg_output_time_path(module_name)),

--- a/workflow/rules/validate.py
+++ b/workflow/rules/validate.py
@@ -142,16 +142,16 @@ def validate_algorithms():
     # Testing if input_graph_id has an actual run.
     for key, runs in config["resources"]["structure_learning_algorithms"].items():
         for run in runs:
-            if 'input_graph_id' in run:
-                if isinstance(run['input_graph_id'], list):
-                    for input_graph in run['input_graph_id']:
+            if 'input_algorithm_id' in run:
+                if isinstance(run['input_algorithm_id'], list):
+                    for input_graph in run['input_algorithm_id']:
                         path = valid_path(input_graph)
                         if not path: 
-                            raise Exception(f"In algorithm {key}, 'input_graph_id' {input_graph} is not available in the config file, or the associated config has parameters with multiple values!")
+                            raise Exception(f"In algorithm {key}, 'input_algorithm_id' {input_graph} is not available in the config file, or the associated config has parameters with multiple values!")
                 else:
-                    path = valid_path(run['input_graph_id'])
+                    path = valid_path(run['input_algorithm_id'])
                     if not path: 
-                        raise Exception(f"In algorithm {key}, 'input_graph_id' {run['input_graph_id']} is not available in the config file, or the associated config has parameters with multiple values!")
+                        raise Exception(f"In algorithm {key}, 'input_algorithm_id' {run['input_algorithm_id']} is not available in the config file, or the associated config has parameters with multiple values!")
     
 
 

--- a/workflow/rules/validate.py
+++ b/workflow/rules/validate.py
@@ -86,5 +86,73 @@ def validate_data_setup(config, dict):
                         "The available paremeter id´s are:\n" + str(sorted(available_conf_ids)))
 
 
+
+   
 for data_setup in config["benchmark_setup"]["data"]:
     validate_data_setup(config, data_setup)
+
+
+    
+from typing import Optional, List, Union, Tuple
+
+""" set of functions to nest algorithms """
+def valid_path(run_id: Optional[str]) -> bool:
+    """ Returns the path to the estimated graph of each id"""
+    
+    if not run_id:
+        return False
+    
+    alg, run_config = idtoalg(run_id)
+    if not alg:
+        return False
+    
+    if not is_single_output_run(run_config):
+        return False
+    
+    return True
+    # if alg in mcmc_modules:
+    #     return expand(pattern_strings[alg]+"/"+pattern_strings["mcmc_est"], **run_config)
+    # else:
+    #     return expand(pattern_strings[alg], **run_config)
+
+
+def idtoalg(run_id: str) -> Optional[Tuple[str, dict]]:
+    """ Returns the algorithm name that the id belongs to, otherwise None """
+    for key, alg in config["resources"]["structure_learning_algorithms"].items():
+        for obj in alg:
+            if obj["id"] == run_id:
+                return key, obj
+    return None, None
+
+
+def is_single_output_run(run_config: dict) -> bool:
+    """ checks if the run is a single output run, i.e., no parameters is with a list lager > 1"""
+    
+    for key, item in run_config.items():
+        if isinstance(item, list):
+            if len(item) > 1: 
+                return False
+    
+    return True
+    
+ 
+
+def validate_algorithms():
+    """ Random validation tests for config"""
+    # Testing if input_graph_id has an actual run.
+    for key, runs in config["resources"]["structure_learning_algorithms"].items():
+        for run in runs:
+            if 'input_graph_id' in run:
+                if isinstance(run['input_graph_id'], list):
+                    for input_graph in run['input_graph_id']:
+                        path = valid_path(input_graph)
+                        if not path: 
+                            raise Exception(f"In algorithm {key}, 'input_graph_id' {input_graph} is not available in the config file, or the associated config has parameters with multiple values!")
+                else:
+                    path = valid_path(run['input_graph_id'])
+                    if not path: 
+                        raise Exception(f"In algorithm {key}, 'input_graph_id' {run['input_graph_id']} is not available in the config file, or the associated config has parameters with multiple values!")
+    
+
+
+validate_algorithms()


### PR DESCRIPTION
This PR is supposed to prototype nesting algorithms. A user can pass `input_algorithm_id` inside their structural learning configuration. The code will 

1. Validate that the input id corresponds to a configuration that  has a single parameter setup. i.e., no parameters with lists of size more than 1. 
2. Generate the location of the input graph, which will be generally in `results/adjmat_estimate/...../adjmat.csv`

The algorithm is then free to use this input.



The logic of the code. 

1. Every algorithm `id` has a dictionary input in `json_string` variable in [here](https://github.com/felixleopoldo/benchpress/blob/0646104b6fe5e51b2c4bc3de1019b6e0ff554e97/workflow/rules/module_strings.py#L40)
2. The validation function [validate_algorithm](https://github.com/felixleopoldo/benchpress/blob/531990ade9b1bba8297e35d4a2b8ff35de446328/workflow/rules/validate.py#L140) checks if the `input_algorithm_id` has a single set-up. 
3. If all good, the function in `def path_to_input_algorithm_graph` in [here](https://github.com/felixleopoldo/benchpress/blob/531990ade9b1bba8297e35d4a2b8ff35de446328/workflow/rules/filename_patterns.py#L78) creates the path to the input file. 
4. All the user has to do, is add this line to their `rule.smk` file under `input`.  
```
input_algorithm=lambda wildcards: path_to_input_algorithm_graph(wildcards.input_algorithm_id) if hasattr(wildcards, 'input_algorithm_id') else "None",
```

Then they can access the variable `input_algorithm` in their code script. 