### PR TITLE
Wrapping feature for diffplots and adjmats

### DIFF
--- a/workflow/rules/evaluation/graph_estimation/adjmat_diffplot.py
+++ b/workflow/rules/evaluation/graph_estimation/adjmat_diffplot.py
@@ -7,38 +7,48 @@ import matplotlib
 matplotlib.use('Agg')
 
 # If the algorithm was timed out or no true graph was provided in benchmark_setup.
-if (os.stat(snakemake.input["adjmat_true"]).st_size == 0)  or (os.stat(snakemake.input["adjmat_est"]).st_size == 0):
-    open(snakemake.output["filename"],'a').close()
+if (os.stat(snakemake.input["adjmat_true"]).st_size == 0) or (os.stat(snakemake.input["adjmat_est"]).st_size == 0):
+    open(snakemake.output["filename"], 'a').close()
 else:
-  adjmat_true = pd.read_csv(snakemake.input["adjmat_true"])
-  adjmat_est = pd.read_csv(snakemake.input["adjmat_est"])
+    adjmat_true = pd.read_csv(snakemake.input["adjmat_true"])
+    adjmat_est = pd.read_csv(snakemake.input["adjmat_est"])
 
-  adjmat_diff = 2*adjmat_true - adjmat_est
-  adjmat_diff = adjmat_diff.replace([1], 3)
-  adjmat_diff = adjmat_diff.replace([2], 1)
-  adjmat_diff = adjmat_diff.replace([-1], 2)
-  heatmap = adjmat_diff
-  # 0: no edge
-  # 1: false negative
-  # 2: false positive
-  # 3: correct edge
+    adjmat_diff = 2*adjmat_true - adjmat_est
+    adjmat_diff = adjmat_diff.replace([1], 3)
+    adjmat_diff = adjmat_diff.replace([2], 1)
+    adjmat_diff = adjmat_diff.replace([-1], 2)
+    heatmap = adjmat_diff
+    # 0: no edge
+    # 1: false negative
+    # 2: false positive
+    # 3: correct edge
 
-  colors = ["light grey", "windows blue", "red", "black"]
-  cmap = sns.xkcd_palette(colors)
-  heatmap.index = heatmap.columns
-  #sns.set_style("whitegrid")
-  with sns.axes_style("white"):
-      sns.heatmap(heatmap,  annot=False, linewidth=1,
-                  cmap=cmap,
-                  vmin=0.0, vmax=3.0, square=True,
-                  cbar=False,
-                  xticklabels=1, yticklabels=1)
-  cax = plt.gcf().axes[-1]
-  cax.tick_params(labelsize=6)
-  plt.title(snakemake.params["title"], fontsize=6, ha="center")
-  if snakemake.params["alg_string"]:
-      plt.ylabel("Algorithm:\n\n"+snakemake.params["alg_string"].replace("/", "\n")  + "\n\n" + "Graph type: " + snakemake.params["graph_type"], 
-              rotation="horizontal", fontsize=6, ha="right", va="center")
-  plt.tight_layout()
-  plt.savefig(snakemake.output["filename"])
-  plt.clf()
+    colors = ["light grey", "windows blue", "red", "black"]
+    cmap = sns.xkcd_palette(colors)
+    heatmap.index = heatmap.columns
+    # sns.set_style("whitegrid")
+    with sns.axes_style("white"):
+        sns.heatmap(heatmap,  annot=False, linewidth=1,
+                    cmap=cmap,
+                    vmin=0.0, vmax=3.0, square=True,
+                    cbar=False,
+                    xticklabels=1, yticklabels=1)
+    cax = plt.gcf().axes[-1]
+    cax.tick_params(labelsize=6)
+    plt.title(snakemake.params["title"], fontsize=6, ha="center")
+    if snakemake.params["alg_string"]:
+        unwrapped = snakemake.params["alg_string"].replace(
+            "/", "\n")  # newlines separate the parameters
+        wrapped_lines = []
+        for line in unwrapped.splitlines():
+            wrapped = [line[i:i+25] for i in range(0, len(line), 25)]
+            wrapped_lines.extend(wrapped)
+        wrapped_alg_string = "\n".join(wrapped_lines)
+        type = snakemake.params["graph_type"]
+        ylabel_text = f"Algorithm:\n\n{wrapped_alg_string}\n\nGraph type: {type}"
+        plt.ylabel(ylabel_text, rotation="horizontal",
+                   fontsize=6, ha="right", va="center")
+
+    plt.tight_layout()
+    plt.savefig(snakemake.output["filename"])
+    plt.clf()

--- a/workflow/rules/evaluation/graph_estimation/plot_matrix_as_heatmap.py
+++ b/workflow/rules/evaluation/graph_estimation/plot_matrix_as_heatmap.py
@@ -8,8 +8,8 @@ matplotlib.use('Agg')
 sns.set(rc={"figure.dpi": 300, 'savefig.dpi': 300})
 
 # If the algorithm was timed out
-if os.stat(snakemake.input["matrix_filename"]).st_size== 0:
-    open(snakemake.output["plot_filename"],'a').close()
+if os.stat(snakemake.input["matrix_filename"]).st_size == 0:
+    open(snakemake.output["plot_filename"], 'a').close()
 else:
     heatmap = pd.read_csv(snakemake.input["matrix_filename"])
     heatmap.index = heatmap.columns
@@ -24,8 +24,17 @@ else:
     cax.tick_params(labelsize=6)
     plt.title(snakemake.params["title"], fontsize=6, ha="center")
     if snakemake.params["alg_string"]:
-        plt.ylabel("Algorithm:\n\n"+snakemake.params["alg_string"].replace("/", "\n") + "\n\n" + "Graph type: " + snakemake.params["graph_type"], 
-                rotation="horizontal", fontsize=6, ha="right", va="center")
+        unwrapped = snakemake.params["alg_string"].replace(
+            "/", "\n")  # newlines separate the parameters
+        wrapped_lines = []
+        for line in unwrapped.splitlines():
+            wrapped = [line[i:i+25] for i in range(0, len(line), 25)]
+            wrapped_lines.extend(wrapped)
+        wrapped_alg_string = "\n".join(wrapped_lines)
+        type = snakemake.params["graph_type"]
+        ylabel_text = f"Algorithm:\n\n{wrapped_alg_string}\n\nGraph type: {type}"
+        plt.ylabel(ylabel_text, rotation="horizontal",
+                   fontsize=6, ha="right", va="center")
     plt.tight_layout()
     plt.savefig(snakemake.output["plot_filename"])
     plt.clf()

--- a/workflow/rules/evaluation/graph_plots/adjmat_diffplot.py
+++ b/workflow/rules/evaluation/graph_plots/adjmat_diffplot.py
@@ -7,38 +7,47 @@ import matplotlib
 matplotlib.use('Agg')
 
 # If the algorithm was timed out or no true graph was provided in benchmark_setup.
-if (os.stat(snakemake.input["adjmat_true"]).st_size == 0)  or (os.stat(snakemake.input["adjmat_est"]).st_size == 0):
-    open(snakemake.output["filename"],'a').close()
+if (os.stat(snakemake.input["adjmat_true"]).st_size == 0) or (os.stat(snakemake.input["adjmat_est"]).st_size == 0):
+    open(snakemake.output["filename"], 'a').close()
 else:
-  adjmat_true = pd.read_csv(snakemake.input["adjmat_true"])
-  adjmat_est = pd.read_csv(snakemake.input["adjmat_est"])
+    adjmat_true = pd.read_csv(snakemake.input["adjmat_true"])
+    adjmat_est = pd.read_csv(snakemake.input["adjmat_est"])
 
-  adjmat_diff = 2*adjmat_true - adjmat_est
-  adjmat_diff = adjmat_diff.replace([1], 3)
-  adjmat_diff = adjmat_diff.replace([2], 1)
-  adjmat_diff = adjmat_diff.replace([-1], 2)
-  heatmap = adjmat_diff
-  # 0: no edge
-  # 1: false negative
-  # 2: false positive
-  # 3: correct edge
+    adjmat_diff = 2*adjmat_true - adjmat_est
+    adjmat_diff = adjmat_diff.replace([1], 3)
+    adjmat_diff = adjmat_diff.replace([2], 1)
+    adjmat_diff = adjmat_diff.replace([-1], 2)
+    heatmap = adjmat_diff
+    # 0: no edge
+    # 1: false negative
+    # 2: false positive
+    # 3: correct edge
 
-  colors = ["light grey", "windows blue", "red", "black"]
-  cmap = sns.xkcd_palette(colors)
-  heatmap.index = heatmap.columns
-  #sns.set_style("whitegrid")
-  with sns.axes_style("white"):
-      sns.heatmap(heatmap,  annot=False, linewidth=1,
-                  cmap=cmap,
-                  vmin=0.0, vmax=3.0, square=True,
-                  cbar=False,
-                  xticklabels=1, yticklabels=1)
-  cax = plt.gcf().axes[-1]
-  cax.tick_params(labelsize=6)
-  plt.title(snakemake.params["title"], fontsize=6, ha="center")
-  if snakemake.params["alg_string"]:
-      plt.ylabel("Algorithm:\n\n"+snakemake.params["alg_string"].replace("/", "\n"),
-              rotation="horizontal", fontsize=6, ha="right", va="center")
-  plt.tight_layout()
-  plt.savefig(snakemake.output["filename"])
-  plt.clf()
+    colors = ["light grey", "windows blue", "red", "black"]
+    cmap = sns.xkcd_palette(colors)
+    heatmap.index = heatmap.columns
+    # sns.set_style("whitegrid")
+    with sns.axes_style("white"):
+        sns.heatmap(heatmap,  annot=False, linewidth=1,
+                    cmap=cmap,
+                    vmin=0.0, vmax=3.0, square=True,
+                    cbar=False,
+                    xticklabels=1, yticklabels=1)
+    cax = plt.gcf().axes[-1]
+    cax.tick_params(labelsize=6)
+    plt.title(snakemake.params["title"], fontsize=6, ha="center")
+    if snakemake.params["alg_string"]:
+        unwrapped = snakemake.params["alg_string"].replace(
+            "/", "\n")  # newlines separate the parameters
+        wrapped_lines = []
+        for line in unwrapped.splitlines():
+            wrapped = [line[i:i+25] for i in range(0, len(line), 25)]
+            wrapped_lines.extend(wrapped)
+        wrapped_alg_string = "\n".join(wrapped_lines)
+        type = snakemake.params["graph_type"]
+        ylabel_text = f"Algorithm:\n\n{wrapped_alg_string}\n\nGraph type: {type}"
+        plt.ylabel(ylabel_text, rotation="horizontal",
+                   fontsize=6, ha="right", va="center")
+    plt.tight_layout()
+    plt.savefig(snakemake.output["filename"])
+    plt.clf()

--- a/workflow/rules/evaluation/graph_plots/plot_matrix_as_heatmap.py
+++ b/workflow/rules/evaluation/graph_plots/plot_matrix_as_heatmap.py
@@ -8,8 +8,8 @@ matplotlib.use('Agg')
 sns.set(rc={"figure.dpi": 300, 'savefig.dpi': 300})
 
 # If the algorithm was timed out
-if os.stat(snakemake.input["matrix_filename"]).st_size== 0:
-    open(snakemake.output["plot_filename"],'a').close()
+if os.stat(snakemake.input["matrix_filename"]).st_size == 0:
+    open(snakemake.output["plot_filename"], 'a').close()
 else:
     heatmap = pd.read_csv(snakemake.input["matrix_filename"])
     heatmap.index = heatmap.columns
@@ -24,8 +24,17 @@ else:
     cax.tick_params(labelsize=6)
     plt.title(snakemake.params["title"], fontsize=6, ha="center")
     if snakemake.params["alg_string"]:
-        plt.ylabel("Algorithm:\n\n"+snakemake.params["alg_string"].replace("/", "\n"),
-                rotation="horizontal", fontsize=6, ha="right", va="center")
+        unwrapped = snakemake.params["alg_string"].replace(
+            "/", "\n")  # newlines separate the parameters
+        wrapped_lines = []
+        for line in unwrapped.splitlines():
+            wrapped = [line[i:i+25] for i in range(0, len(line), 25)]
+            wrapped_lines.extend(wrapped)
+        wrapped_alg_string = "\n".join(wrapped_lines)
+        type = snakemake.params["graph_type"]
+        ylabel_text = f"Algorithm:\n\n{wrapped_alg_string}\n\nGraph type: {type}"
+        plt.ylabel(ylabel_text, rotation="horizontal",
+                   fontsize=6, ha="right", va="center")
     plt.tight_layout()
     plt.savefig(snakemake.output["plot_filename"])
     plt.clf()

--- a/workflow/rules/evaluation/graph_true_plots/plot_matrix_as_heatmap.py
+++ b/workflow/rules/evaluation/graph_true_plots/plot_matrix_as_heatmap.py
@@ -8,8 +8,8 @@ matplotlib.use('Agg')
 sns.set(rc={"figure.dpi": 300, 'savefig.dpi': 300})
 
 # If the algorithm was timed out
-if os.stat(snakemake.input["matrix_filename"]).st_size== 0:
-    open(snakemake.output["plot_filename"],'a').close()
+if os.stat(snakemake.input["matrix_filename"]).st_size == 0:
+    open(snakemake.output["plot_filename"], 'a').close()
 else:
     heatmap = pd.read_csv(snakemake.input["matrix_filename"])
     heatmap.index = heatmap.columns
@@ -24,8 +24,17 @@ else:
     cax.tick_params(labelsize=6)
     plt.title(snakemake.params["title"], fontsize=6, ha="center")
     if snakemake.params["alg_string"]:
-        plt.ylabel("Algorithm:\n\n"+snakemake.params["alg_string"].replace("/", "\n"),
-                rotation="horizontal", fontsize=6, ha="right", va="center")
+        unwrapped = snakemake.params["alg_string"].replace(
+            "/", "\n")  # newlines separate the parameters
+        wrapped_lines = []
+        for line in unwrapped.splitlines():
+            wrapped = [line[i:i+25] for i in range(0, len(line), 25)]
+            wrapped_lines.extend(wrapped)
+        wrapped_alg_string = "\n".join(wrapped_lines)
+        type = snakemake.params["graph_type"]
+        ylabel_text = f"Algorithm:\n\n{wrapped_alg_string}\n\nGraph type: {type}"
+        plt.ylabel(ylabel_text, rotation="horizontal",
+                   fontsize=6, ha="right", va="center")
     plt.tight_layout()
     plt.savefig(snakemake.output["plot_filename"])
     plt.clf()

--- a/workflow/rules/evaluation/mcmc_autocorr_plots/plot_autocorr_from_traj.py
+++ b/workflow/rules/evaluation/mcmc_autocorr_plots/plot_autocorr_from_traj.py
@@ -12,7 +12,7 @@ import networkx as nx
 import matplotlib
 matplotlib.use('Agg')
 
-#from pandas.compat import lmap
+# from pandas.compat import lmap
 
 
 def autocorrelation_plot(series, n_samples=None, ax=None, **kwds):
@@ -73,8 +73,8 @@ def edges_str_to_list(str, edgesymb="-"):
 
 # Treating the case when empty files are created. Such files
 # are created if the algorithm was timed out.
-if os.stat(snakemake.input["traj"]).st_size== 0:
-    open(snakemake.output["plot"],'a').close()
+if os.stat(snakemake.input["traj"]).st_size == 0:
+    open(snakemake.output["plot"], 'a').close()
 else:
 
     df = pd.read_csv(snakemake.input["traj"], sep=",")
@@ -109,12 +109,12 @@ else:
             columns=df2.columns)
         # incase series index doens't start at 0
         if not np.char.isnumeric(['size'][0]):
-            df2.at[0,'size'] = int(0)
+            df2.at[0, 'size'] = int(0)
 
         df2 = df2.fillna(method="ffill")
 
         burnin = int(float(snakemake.wildcards["burn_in"]) * df2.shape[0])
-        
+
         if snakemake.wildcards["thinning"] != "None":
             thinning = int(snakemake.wildcards["thinning"])
             dfplot = df2["size"][burnin:].iloc[::thinning]
@@ -133,7 +133,7 @@ else:
             columns=df2.columns)
         # incase series index doens't start at 0
         if not np.char.isnumeric(['score'][0]):
-            df2.at[0,'score'] = int(0)
+            df2.at[0, 'score'] = int(0)
 
         df2 = df2.fillna(method="ffill")
         burnin = int(float(snakemake.wildcards["burn_in"]) * df2.shape[0])
@@ -147,7 +147,7 @@ else:
         sm.graphics.tsa.plot_acf(dfplot, lags=int(snakemake.wildcards["lags"]))
     else:
         sm.graphics.tsa.plot_acf(dfplot)
-    #autocorrelation_plot(df2["size"][int(snakemake.wildcards["burn_in"]):], n_samples=int(snakemake.wildcards["lags"]))
+    # autocorrelation_plot(df2["size"][int(snakemake.wildcards["burn_in"]):], n_samples=int(snakemake.wildcards["lags"]))
 
     # nlags = int(snakemake.wildcards["lags"])
     # lags = [dfplot.autocorr(lag=l) for l in range(1, nlags + 1)]
@@ -156,15 +156,24 @@ else:
 
     # df.dropna().plot(x="nlags", y="autocorr")
 
-    #plt.acorr(dfplot.values, usevlines=True, normed=True, maxlags=nlags)
+    # plt.acorr(dfplot.values, usevlines=True, normed=True, maxlags=nlags)
     plt.title("Graph: "+snakemake.params["adjmat_string"] + "\nParameters: " +
-            snakemake.params["param_string"] + "\nData: " + snakemake.params["data_string"], fontsize=6, ha="center")
-    plt.ylabel(
-        "Algorithm:\n\n"+snakemake.params["alg_string"].replace("/", "\n") +
-        "\n\nPlot:\n\nburn_in="+snakemake.wildcards["burn_in"] +
-        "\nthinning="+snakemake.wildcards["thinning"] +
-        "\nlags="+snakemake.wildcards["lags"] +
-        "\nfunctional="+snakemake.wildcards["functional"], rotation="horizontal", fontsize=6, ha="right", va="center")
+              snakemake.params["param_string"] + "\nData: " + snakemake.params["data_string"], fontsize=6, ha="center")
+
+    unwrapped = snakemake.params["alg_string"].replace(
+        "/", "\n")  # newlines separate the parameters
+    wrapped_lines = []
+    for line in unwrapped.splitlines():
+        wrapped = [line[i:i+25] for i in range(0, len(line), 25)]
+        wrapped_lines.extend(wrapped)
+    wrapped_alg_string = "\n".join(wrapped_lines)
+    type = snakemake.params["graph_type"]
+    ylabel_text = "Algorithm:\n\n" + wrapped_alg_string + "\n\nPlot:\n\nburn_in=" + \
+        snakemake.wildcards["burn_in"] + "\nthinning="+snakemake.wildcards["thinning"] + \
+        "\nlags="+snakemake.wildcards["lags"] + \
+        "\nfunctional="+snakemake.wildcards["functional"]
+    plt.ylabel(ylabel_text, rotation="horizontal",
+               fontsize=6, ha="right", va="center")
 
     plt.xlabel("Lag/"+snakemake.wildcards["thinning"], fontsize=6)
     cax = plt.gcf().axes[-1]

--- a/workflow/rules/evaluation/mcmc_heatmaps/plot_heatmap_from_graphtraj.py
+++ b/workflow/rules/evaluation/mcmc_heatmaps/plot_heatmap_from_graphtraj.py
@@ -1,16 +1,16 @@
 # Reads a grap trajectory and plots a heatmap of the expected graph.
-sys.path.append("workflow/scripts/evaluation")
-import os
-
-from sklearn.cluster import estimate_bandwidth
-import networkx as nx
-import numpy as np
-import seaborn as sns
-import matplotlib.pyplot as plt
-import pandas as pd
-import matplotlib
-import math
 from mcmc_utils import *
+import math
+import matplotlib
+import pandas as pd
+import matplotlib.pyplot as plt
+import seaborn as sns
+import numpy as np
+import networkx as nx
+from sklearn.cluster import estimate_bandwidth
+import os
+sys.path.append("workflow/scripts/evaluation")
+
 
 matplotlib.use('Agg')
 sns.set(rc={"figure.dpi": 300, 'savefig.dpi': 300})
@@ -18,24 +18,25 @@ sns.set(rc={"figure.dpi": 300, 'savefig.dpi': 300})
 
 # Treating the case when empty files are created. Such files
 # are created if the algorithm was timed out.
-if os.stat(snakemake.input["traj"]).st_size== 0:
-    open(snakemake.output["filename"],'a').close()
+if os.stat(snakemake.input["traj"]).st_size == 0:
+    open(snakemake.output["filename"], 'a').close()
 else:
     df = pd.read_csv(snakemake.input["traj"], sep=",")
 
     edgesymb = get_edge_symb(df)
     nodeorder = get_node_order(df)
-    
+
     # Create heatmap
-    heatmap = estimate_heatmap(df, float(snakemake.params["burnin_frac"]), edgesymb)
-    
+    heatmap = estimate_heatmap(
+        df, float(snakemake.params["burnin_frac"]), edgesymb)
+
     ### Create heatmap plot ###
-    
+
     # need to reorganize matrix according to node orders..
     sns.set(font_scale=0.4)
     with sns.axes_style("white"):
-        sns.heatmap(heatmap, 
-                    annot=True, 
+        sns.heatmap(heatmap,
+                    annot=True,
                     linewidth=1,
                     fmt=".2f",
                     cmap="Blues",
@@ -48,42 +49,51 @@ else:
     cax.tick_params(labelsize=6)
 
     plt.title("Graph: "+snakemake.params["adjmat_string"] + "\nParameters: " +
-            snakemake.params["param_string"] + "\nData: " + snakemake.params["data_string"], fontsize=6, ha="center")
-    plt.ylabel("Algorithm:\n\n"+snakemake.params["alg_string"].replace("/", "\n") + "\n\nburn_in=" +
-            snakemake.wildcards["burn_in"], rotation="horizontal", fontsize=6, ha="right", va="center")
+              snakemake.params["param_string"] + "\nData: " + snakemake.params["data_string"], fontsize=6, ha="center")
+
+    unwrapped = snakemake.params["alg_string"].replace(
+        "/", "\n")  # newlines separate the parameters
+    wrapped_lines = []
+    for line in unwrapped.splitlines():
+        wrapped = [line[i:i+25] for i in range(0, len(line), 25)]
+        wrapped_lines.extend(wrapped)
+    wrapped_alg_string = "\n".join(wrapped_lines)
+    burn_in = snakemake.wildcards["burn_in"]
+    ylabel_text = f"Algorithm:\n\n{wrapped_alg_string}\n\nburn_in={burn_in}"
+    plt.ylabel(ylabel_text, rotation="horizontal",
+               fontsize=6, ha="right", va="center")
 
     plt.tight_layout()
-    
+
     plt.savefig(snakemake.output["heatmap_plot"])
     plt.clf()
 
     #### Create heatgraph plot ###
     mapping = {i: val for i, val in enumerate(nodeorder)}
-    
-        # Here we create a networkx graph with edge weights from the heatmap
+
+    # Here we create a networkx graph with edge weights from the heatmap
     # first check if directed or not.
     edges = edges_str_to_list(df["added"][0], edgesymb)
     graph = None
-    
+
     if edgesymb == "-":
         graph = nx.from_numpy_array(heatmap.values, create_using=nx.Graph())
-    elif edgesymb == "->":        
+    elif edgesymb == "->":
         graph = nx.from_numpy_array(heatmap.values, create_using=nx.DiGraph())
-    
+
     graph = nx.relabel_nodes(graph, mapping)
 
     for edge in graph.edges(data=True):
-        
+
         weight = edge[2]["weight"]
-        edge[2]["label"] = round(weight, 2)        
+        edge[2]["label"] = round(weight, 2)
         edge[2]["color"] = "black"
         edge[2]["penwidth"] = weight
-    
-    # create the pygraphviz graph    
+
+    # create the pygraphviz graph
     A = nx.nx_agraph.to_agraph(graph)
 
-    #A.layout("circo")
+    # A.layout("circo")
     A.layout("dot")
-    A.draw(snakemake.output["heatmap_plot"]+"-graph.png") # args="mindist=2.0")
-
-   
+    # args="mindist=2.0")
+    A.draw(snakemake.output["heatmap_plot"]+"-graph.png")

--- a/workflow/rules/evaluation/mcmc_heatmaps/plot_matrix_as_heatmap.py
+++ b/workflow/rules/evaluation/mcmc_heatmaps/plot_matrix_as_heatmap.py
@@ -8,8 +8,8 @@ matplotlib.use('Agg')
 sns.set(rc={"figure.dpi": 300, 'savefig.dpi': 300})
 
 # If the algorithm was timed out
-if os.stat(snakemake.input["matrix_filename"]).st_size== 0:
-    open(snakemake.output["plot_filename"],'a').close()
+if os.stat(snakemake.input["matrix_filename"]).st_size == 0:
+    open(snakemake.output["plot_filename"], 'a').close()
 else:
     heatmap = pd.read_csv(snakemake.input["matrix_filename"])
     heatmap.index = heatmap.columns
@@ -24,8 +24,17 @@ else:
     cax.tick_params(labelsize=6)
     plt.title(snakemake.params["title"], fontsize=6, ha="center")
     if snakemake.params["alg_string"]:
-        plt.ylabel("Algorithm:\n\n"+snakemake.params["alg_string"].replace("/", "\n"),
-                rotation="horizontal", fontsize=6, ha="right", va="center")
+        unwrapped = snakemake.params["alg_string"].replace(
+            "/", "\n")  # newlines separate the parameters
+        wrapped_lines = []
+        for line in unwrapped.splitlines():
+            wrapped = [line[i:i+25] for i in range(0, len(line), 25)]
+            wrapped_lines.extend(wrapped)
+        wrapped_alg_string = "\n".join(wrapped_lines)
+        type = snakemake.params["graph_type"]
+        ylabel_text = f"Algorithm:\n\n{wrapped_alg_string}\n\nGraph type: {type}"
+        plt.ylabel(ylabel_text, rotation="horizontal",
+                   fontsize=6, ha="right", va="center")
     plt.tight_layout()
     plt.savefig(snakemake.output["plot_filename"])
     plt.clf()


### PR DESCRIPTION
Changes made to 8 files. Most differences are just formatting on save automatically (not changing anything). Real changes are in each file before plt.ylabel(). The files previously took alg string ex /param1/param2/param3, then split and added newlines where / were present. New version still does this, but additionally looks through each line and sets a max width of 25, and if greater, it will wrap around (add a newline character) to prevent the label from either going of the page or extending the image. 